### PR TITLE
Add example usage with telethon

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ As you can see, special function that is provided should be passed to callback q
 
 In the body of the handler function you need to call process function on callback data. **WARNING!** You need to create the calendar object again if it was not saved before.
 
-The function `process` return tuple of size 3 - `result`, `keyboard`, `step`. 
+The function `process` return tuple of size 3 - `result`, `keyboard`, `step`.
 
 * `result` - `datetime.date` object if user finished selecting. Otherwise `None`
 * `keyboard` - inline keyboard markup if the result is not ready. Otherwise `None`
@@ -80,7 +80,7 @@ In the class constructor `min_date` and `max_date` - both are used as min and ma
 
 You can also write your own code. One of the examples is redefining the steps order.
 
-In the package you can find `WMonthTelegramCalendar` and `WYearTelegramCalendar` that start from day and month selecting, not from year. 
+In the package you can find `WMonthTelegramCalendar` and `WYearTelegramCalendar` that start from day and month selecting, not from year.
 
 You can also redefine style parameters. Example:
 
@@ -117,6 +117,7 @@ class MyTranslationCalendar(DetailedTelegramCalendar):
 
 * [simple_pytelegrambotapi.py](/examples/simple_pytelegrambotapi.py) - simple example with [pyTelegramBotAPI](https://github.com/eternnoir/pyTelegramBotAPI)
 * [simple_aiogram.py](/examples/simple_aiogram.py) - simple example with [aiogram](https://github.com/aiogram/aiogram)
+* [simple_telethon.py](/examples/simple_telethon.py) - simple example with [telethon](https://github.com/LonamiWebs/Telethon)
 * [custom_translation.py](examples/custom_translation.py) - custom translation of calendar
 * [date_ranges.py](/examples/date_ranges.py) - define date ranges for the bot
 * [redefine_style.py](/examples/redefine_style.py) - simple example of redefining styles

--- a/examples/simple_telethon.py
+++ b/examples/simple_telethon.py
@@ -9,58 +9,25 @@ from telegram_bot_calendar import DetailedTelegramCalendar, LSTEP
 import json
 from typing import List, Dict, Callable
 
-api_id = 1234567
-api_hash = "api-hash-here"
-bot_token = "bot-token-here"
+api_id = 123456
+api_hash = "1233456789"
+bot_token = "token"
 
 bot = TelegramClient("bot", api_id, api_hash)
 
 
-def build_buttons(markup: str) -> List[List[Button]]:
-    # Telethon uses Telegram's MTProto protocol directly
-    # instead of relying on the Bot API. This means
-    # that telethon doesn't send or recieve data in json
-    # and so we have to parse the text and callback data
-    # of buttons to proper objects.
-
-    button_markup_data: Dict = json.loads(markup)
-
-    buttons: List[List[Button]] = []
-    for button_row in button_markup_data["inline_keyboard"]:
-        button_row: List[Dict]
-        buttons.append(
-            [
-                Button.inline(text=str(but["text"]), data=but["callback_data"])
-                for but in button_row
-            ]
-        )
-
-    return buttons
-
-
-def callback_filter(calendar_id=0) -> Callable:
-    # Due to differences in design, we cannot use
-    # DetailedTelegramCalendar.func() directly for telethon
-
-    def inner(callback_data: bytes) -> bool:
-        start = telegram_bot_calendar.base.CB_CALENDAR + "_" + str(calendar_id)
-        return callback_data.decode("utf-8").startswith(start)
-
-    return inner
-
-
 @bot.on(events.NewMessage(pattern="/start"))
 async def reply_handler(event):
-    calendar, step = DetailedTelegramCalendar().build()
-    await event.respond(f"Select {LSTEP[step]}", buttons=build_buttons(calendar))
+    calendar, step = DetailedTelegramCalendar(telethon=True).build()
+    await event.respond(f"Select {LSTEP[step]}", buttons=calendar)
 
 
-@bot.on(events.CallbackQuery(pattern=callback_filter()))
+@bot.on(events.CallbackQuery(pattern=DetailedTelegramCalendar.func(telethon=True)))
 async def calendar_handler(event):
-    result, key, step = DetailedTelegramCalendar().process(event.data.decode("utf-8"))
+    result, key, step = DetailedTelegramCalendar(telethon=True).process(event.data.decode("utf-8"))
 
     if not result and key:
-        await event.edit(f"Select {LSTEP[step]}", buttons=build_buttons(key))
+        await event.edit(f"Select {LSTEP[step]}", buttons=key)
     elif result:
         await event.edit(f"You selected {result}")
 

--- a/examples/simple_telethon.py
+++ b/examples/simple_telethon.py
@@ -1,0 +1,70 @@
+"""
+Example using telethon.
+"""
+
+from telethon import Button, TelegramClient, events
+import telegram_bot_calendar.base
+from telegram_bot_calendar import DetailedTelegramCalendar, LSTEP
+
+import json
+from typing import List, Dict, Callable
+
+api_id = 1234567
+api_hash = "api-hash-here"
+bot_token = "bot-token-here"
+
+bot = TelegramClient("bot", api_id, api_hash)
+
+
+def build_buttons(markup: str) -> List[List[Button]]:
+    # Telethon uses Telegram's MTProto protocol directly
+    # instead of relying on the Bot API. This means
+    # that telethon doesn't send or recieve data in json
+    # and so we have to parse the text and callback data
+    # of buttons to proper objects.
+
+    button_markup_data: Dict = json.loads(markup)
+
+    buttons: List[List[Button]] = []
+    for button_row in button_markup_data["inline_keyboard"]:
+        button_row: List[Dict]
+        buttons.append(
+            [
+                Button.inline(text=str(but["text"]), data=but["callback_data"])
+                for but in button_row
+            ]
+        )
+
+    return buttons
+
+
+def callback_filter(calendar_id=0) -> Callable:
+    # Due to differences in design, we cannot use
+    # DetailedTelegramCalendar.func() directly for telethon
+
+    def inner(callback_data: bytes) -> bool:
+        start = telegram_bot_calendar.base.CB_CALENDAR + "_" + str(calendar_id)
+        return callback_data.decode("utf-8").startswith(start)
+
+    return inner
+
+
+@bot.on(events.NewMessage(pattern="/start"))
+async def reply_handler(event):
+    calendar, step = DetailedTelegramCalendar().build()
+    await event.respond(f"Select {LSTEP[step]}", buttons=build_buttons(calendar))
+
+
+@bot.on(events.CallbackQuery(pattern=callback_filter()))
+async def calendar_handler(event):
+    result, key, step = DetailedTelegramCalendar().process(event.data.decode("utf-8"))
+
+    if not result and key:
+        await event.edit(f"Select {LSTEP[step]}", buttons=build_buttons(key))
+    elif result:
+        await event.edit(f"You selected {result}")
+
+
+bot.start(bot_token=bot_token)
+with bot:
+    bot.run_until_disconnected()

--- a/examples/simple_telethon.py
+++ b/examples/simple_telethon.py
@@ -2,12 +2,9 @@
 Example using telethon.
 """
 
-from telethon import Button, TelegramClient, events
-import telegram_bot_calendar.base
-from telegram_bot_calendar import DetailedTelegramCalendar, LSTEP
+from telethon import TelegramClient, events
 
-import json
-from typing import List, Dict, Callable
+from telegram_bot_calendar import DetailedTelegramCalendar, LSTEP
 
 api_id = 123456
 api_hash = "1233456789"

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding='utf-8') as fh:
 setup(
     name='python-telegram-bot-calendar',
     packages=['telegram_bot_calendar'],
-    version='1.0.4',
+    version='1.0.5',
     license='MIT',
     description='Python inline calendar for telegram bots',
     long_description=long_description,
@@ -19,6 +19,9 @@ setup(
     install_requires=[
         'python-dateutil',
     ],
+    extras_require={
+        'telethon': ['telethon']
+    },
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',

--- a/telegram_bot_calendar/detailed.py
+++ b/telegram_bot_calendar/detailed.py
@@ -13,10 +13,10 @@ class DetailedTelegramCalendar(TelegramCalendar):
 
     def __init__(self, calendar_id=0, current_date=None, additional_buttons=None, locale='en',
                  min_date=None,
-                 max_date=None, **kwargs):
+                 max_date=None, telethon=False, **kwargs):
         super(DetailedTelegramCalendar, self).__init__(calendar_id, current_date=current_date,
                                                        additional_buttons=additional_buttons, locale=locale,
-                                                       min_date=min_date, max_date=max_date)
+                                                       min_date=min_date, max_date=max_date, telethon=telethon, **kwargs)
 
     def _build(self, step=None, **kwargs):
         if not step:

--- a/telegram_bot_calendar/detailed.py
+++ b/telegram_bot_calendar/detailed.py
@@ -16,7 +16,7 @@ class DetailedTelegramCalendar(TelegramCalendar):
                  max_date=None, telethon=False, **kwargs):
         super(DetailedTelegramCalendar, self).__init__(calendar_id, current_date=current_date,
                                                        additional_buttons=additional_buttons, locale=locale,
-                                                       min_date=min_date, max_date=max_date, is_random=is_random, telethon=telethon, **kwargs)
+                                                       min_date=min_date, max_date=max_date, is_random=False, telethon=telethon, **kwargs)
 
     def _build(self, step=None, **kwargs):
         if not step:


### PR DESCRIPTION
[Telethon](https://github.com/LonamiWebs/Telethon) uses the MTProto protocol directly and hence the usage is different. This example showcases how to achieve the simple calendar example in telethon.